### PR TITLE
Major refactoring and adding Pause/Resume feature

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -2,8 +2,9 @@ use regex::Regex;
 use reqwest::Client as HttpClient;
 use serenity::async_trait;
 use songbird::input::Input;
+use songbird::tracks::TrackHandle;
 use songbird::{Event, EventContext, EventHandler as VoiceEventHandler};
-use std::collections::{HashSet, VecDeque};
+use std::collections::VecDeque;
 use std::sync::Arc;
 use tokio::sync::{Mutex, Notify, RwLock};
 
@@ -22,9 +23,9 @@ pub struct Bot {
     pub httpClient: HttpClient,
     pub youtubeRegex: Regex,
     pub queue: Arc<Mutex<VecDeque<Input>>>,
-
     pub notify: Arc<Notify>,
     pub driverStatus: Arc<RwLock<DriverStatus>>,
+    pub currentTrack: Arc<Mutex<Option<TrackHandle>>>,
 }
 
 pub struct TrackEventHandler {
@@ -57,6 +58,7 @@ impl Bot {
             queue: Arc::new(Mutex::new(VecDeque::new())),
             notify: Arc::new(Notify::new()),
             driverStatus: Arc::new(RwLock::new(DriverStatus::Disconnected)),
+            currentTrack: Arc::new(Mutex::new(None))
         }
     }
 }

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -1,8 +1,8 @@
 use regex::Regex;
 use reqwest::Client as HttpClient;
+use serenity::async_trait;
 use serenity::model::id::UserId;
 use serenity::model::user::User;
-use serenity::async_trait;
 use songbird::input::Input;
 use songbird::{Event, EventContext, EventHandler as VoiceEventHandler};
 use std::collections::{HashSet, VecDeque};
@@ -23,7 +23,7 @@ pub enum DriverStatus {
 pub struct Bot {
     pub httpClient: HttpClient,
     pub youtubeRegex: Regex,
-    pub queue: Arc<Mutex<VecDeque<SongMessage>>>,
+    pub queue: Arc<Mutex<VecDeque<Input>>>,
     pub notify: Arc<Notify>,
     pub ignoreList: RwLock<HashSet<User>>,
     pub driverStatus: Arc<RwLock<DriverStatus>>,
@@ -31,7 +31,7 @@ pub struct Bot {
 
 pub struct TrackEventHandler {
     pub notify: Arc<tokio::sync::Notify>,
-    pub queue: Arc<Mutex<VecDeque<SongMessage>>>,
+    pub queue: Arc<Mutex<VecDeque<Input>>>,
     pub driver: Arc<RwLock<DriverStatus>>,
 }
 
@@ -62,10 +62,4 @@ impl Bot {
             driverStatus: Arc::new(RwLock::new(DriverStatus::Disconnected)),
         }
     }
-}
-
-pub struct SongMessage {
-    pub link: String,
-    pub input: Input,
-    pub from: UserId,
 }

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -1,8 +1,6 @@
 use regex::Regex;
 use reqwest::Client as HttpClient;
 use serenity::async_trait;
-use serenity::model::id::UserId;
-use serenity::model::user::User;
 use songbird::input::Input;
 use songbird::{Event, EventContext, EventHandler as VoiceEventHandler};
 use std::collections::{HashSet, VecDeque};
@@ -24,8 +22,8 @@ pub struct Bot {
     pub httpClient: HttpClient,
     pub youtubeRegex: Regex,
     pub queue: Arc<Mutex<VecDeque<Input>>>,
+
     pub notify: Arc<Notify>,
-    pub ignoreList: RwLock<HashSet<User>>,
     pub driverStatus: Arc<RwLock<DriverStatus>>,
 }
 
@@ -58,7 +56,6 @@ impl Bot {
             ).expect("error creating regex"),
             queue: Arc::new(Mutex::new(VecDeque::new())),
             notify: Arc::new(Notify::new()),
-            ignoreList: RwLock::new(HashSet::new()),
             driverStatus: Arc::new(RwLock::new(DriverStatus::Disconnected)),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,21 +1,15 @@
 use bot::Bot;
 use serenity::{
     gateway::ActivityData,
-    model::{
-        id::UserId,
-        user::OnlineStatus::Idle,
-    },
+    model::{id::UserId, user::OnlineStatus::Idle},
     prelude::{Client, GatewayIntents},
 };
 use songbird::SerenityInit;
-use std::{
-    collections::HashSet,
-    env,
-};
+use std::{collections::HashSet, env};
 use tracing::info;
 
-mod commands;
 mod bot;
+mod commands;
 use bot::Error;
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 2)]
@@ -36,7 +30,13 @@ async fn main() {
 
     let framework = poise::Framework::<Bot, Error>::builder()
         .options(poise::FrameworkOptions {
-            commands: vec![commands::ping(), commands::join(), commands::play(), commands::ignore(), commands::pardon(), commands::leave(), commands::skip()],
+            commands: vec![
+                commands::ping(),
+                commands::join(),
+                commands::play(),
+                commands::leave(),
+                commands::skip(),
+            ],
             skip_checks_for_owners: true,
             manual_cooldowns: false,
             owners: HashSet::from([UserId::new(90550255229091840)]),


### PR DESCRIPTION
- Removed a lot of old code that would track data that was only being written to and never read.
- Removed 'banned' user logic that would ignore a user's commands.
- Changed type of queue since `SongMessage` struct was removed
- New data type called `currentTrack` of type `TrackHandler` to be able to pause/resume tracks and possible allow further control such as volume control. 